### PR TITLE
Build docker image for master and development branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,66 @@
+name: 'Build Docker Image'
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - development
+
+env:
+  image-name: ghcr.io/${{ github.repository_owner }}/craftbeerpi4
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Prepare docker image and tag names
+        id: prep
+        run: |
+
+          if [[ $GITHUB_REF_NAME == master ]] || [[ $GITHUB_REF_NAME == main ]]; then
+            # when building master/main use :latest tag and the version number
+            # from the cbpi/__init__.py file
+            VERSION=$(grep -o -E "(([0-9]{1,2}[.]?){3}[0-9]+)" cbpi/__init__.py)
+            TAGS="${{ env.image-name }}:latest,${{ env.image-name }}:v${VERSION}"
+          else
+            # otherwise just use :dev tag
+            TAGS="${{ env.image-name }}:dev"
+          fi
+
+          # Set output parameters.
+          echo ::set-output name=tags::${TAGS}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,43 @@
-FROM python:3.5.6-stretch
+FROM alpine:latest as download
+RUN apk --no-cache add curl && mkdir /downloads
+# Download installation files
+RUN curl https://github.com/avollkopf/craftbeerpi4-ui/archive/main.zip -L -o ./downloads/cbpi-ui.zip
 
-WORKDIR /usr/src/app
+FROM python:3.7-slim
 
-COPY dist/cbpi-0.0.1.tar.gz ./
-RUN pip install cbpi-0.0.1.tar.gz --no-cache-dir
+# Install dependencies
+RUN     apt-get update \
+    &&  apt-get upgrade -y
+RUN apt-get install --no-install-recommends -y \
+    libatlas-base-dev \
+    libffi-dev \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
 
-COPY . .
+RUN python -m pip install --upgrade pip setuptools wheel
 
-EXPOSE 8080
+WORKDIR /cbpi
+# Create non-root user working directory
+RUN groupadd -g 1000 -r craftbeerpi \
+    && useradd -u 1000 -r -s /bin/false -g craftbeerpi craftbeerpi \
+    && chown craftbeerpi:craftbeerpi /cbpi
 
-CMD [ "cbpi" ]
+# Install craftbeerpi from source
+COPY . /cbpi-src
+RUN pip3 install --no-cache-dir /cbpi-src
 
+# Install craftbeerpi-ui
+COPY --from=download /downloads /downloads
+RUN pip3 install --no-cache-dir /downloads/cbpi-ui.zip
 
+# Clean up installation files
+RUN rm -rf /downloads /cbpi-src
+
+USER craftbeerpi
+
+RUN cbpi setup
+
+EXPOSE 8000
+
+# Start cbpi
+CMD ["cbpi", "start"]


### PR DESCRIPTION
I created a repository that contains a `Dockerfile` to create a craftbeerpi4 image according to your documentation page (https://openbrewing.gitbook.io/craftbeerpi4_support/master/server-installation). Thanks for that by the way.

You can find the repository I created here: https://github.com/papauorg/craftbeerpi4-docker.

After sucessfully creating the image I figured that the build process and image should be part of the repository that is actually maintained. So here is my suggestion for a changed Docker image.

I also created the config for a github action that should work in your repository after merging. I tried in my fork, before.
It does the following:
- Builds the docker image for the master and development branches (and main, in case it is renamed to the new default)
- For master it tags the image as `latest` and `v0.0.0.0` - where `0.0.0.0` is the version number from `cbpi/__init__.py`
- For all other builds, it tags the image with 'dev'. This only affects the build when pushing changes to the development branch currently. This gives us a kind oft preview/unstable image e.g. for testing.
- The image is uploaded to the github image registry that is associated with the repository. This would be `ghcr.io/avollkopf/craftbeerpi4` after merging.
- Images are created for `amd64` and `arm64` architectures. I couldn't get it to build for `arm/v7`. I don't know enough about python I guess. But for the 64bit raspberry pi OS it works.

This would lead to continuously updated, runnable images that could easily be consumed by users of craftbeerpi4.

The above mentioned repository also contains a readme that explains how to use the image. I wasn't sure if I should put that information in the readme of your repo with this PR because it's so empty :). But I could add that commit if you want.

Would be awesome to have those images in the 'main' repo!

Please let me know what you think!

Best regards,
Philipp