### PR TITLE
Improve CI build and fix docker build issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,34 @@ env:
   image-name: ghcr.io/${{ github.repository_owner }}/craftbeerpi4
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Builds the source distribution package for CraftBeerPi
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - name: Setup python environment
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+
+      - name: Clean
+        run: python setup.py clean --all
+
+#      - name: Run tests
+#        run: python -m unittest tests
+
+      - name: Build source distribution package for CraftBeerPi
+        run: python setup.py sdist
+
+      - name: Upload CraftBeerPi package to be used in next step
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: craftbeerpi4
+          path: dist/cbpi-*.tar.gz
+          if-no-files-found: error
+
   docker:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
       - main
       - master
       - development
+  pull_request:
 
 env:
   image-name: ghcr.io/${{ github.repository_owner }}/craftbeerpi4
@@ -49,18 +50,22 @@ jobs:
         id: prep
         run: |
 
+          PUBLISH_IMAGE=false
+          TAGS="${{ env.image-name }}:dev"
+
           if [[ $GITHUB_REF_NAME == master ]] || [[ $GITHUB_REF_NAME == main ]]; then
             # when building master/main use :latest tag and the version number
             # from the cbpi/__init__.py file
             VERSION=$(grep -o -E "(([0-9]{1,2}[.]?){3}[0-9]+)" cbpi/__init__.py)
             TAGS="${{ env.image-name }}:latest,${{ env.image-name }}:v${VERSION}"
-          else
-            # otherwise just use :dev tag
-            TAGS="${{ env.image-name }}:dev"
+            PUBLISH_IMAGE=true
+          elif [[ $GITHUB_REF_NAME == development ]]; then
+            PUBLISH_IMAGE=true
           fi
 
           # Set output parameters.
           echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=publish_image::${PUBLISH_IMAGE}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master
@@ -85,7 +90,7 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ steps.prep.outputs.publish_image }}
           tags: ${{ steps.prep.outputs.tags }}
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: 'Build Docker Image'
+name: 'Build CraftBeerPi4'
 
 on:
   push:
@@ -14,7 +14,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Builds the source distribution package for CraftBeerPi
+    name: Builds the source distribution package
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
@@ -42,6 +42,7 @@ jobs:
 
   docker:
     runs-on: ubuntu-latest
+    name: Builds the docker image(s)
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN apk --no-cache add curl && mkdir /downloads
 # Download installation files
 RUN curl https://github.com/avollkopf/craftbeerpi4-ui/archive/main.zip -L -o ./downloads/cbpi-ui.zip
 
-FROM python:3.7-slim
+FROM python:3.7
 
 # Install dependencies
 RUN     apt-get update \


### PR DESCRIPTION
In the last PR #6 I changed the base image to `python3.7-slim` before submitting the PR. Not the best idea as it seems. This broke the build. So here comes the fix for this. It now uses the `python3.7` image (without -slim). 

I also included that the build should be run for each PR and that the python sdist package is built. Images for PR builds are not pushed to the registry. You could also run tests for each PR. But I didn't know what the correct command for this is ...

