### PR TITLE
Avoid root when installing cbpi in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,10 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel
 
+# Install craftbeerpi requirements for better caching
+COPY --chown=craftbeerpi ./requirements.txt /cbpi-src/
+RUN pip3 install --no-cache-dir -r /cbpi-src/requirements.txt
+
 # Install craftbeerpi from source
 COPY --chown=craftbeerpi . /cbpi-src
 RUN pip3 install --no-cache-dir /cbpi-src

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,10 @@ pyfiglet==0.8.post1
 pandas==1.1.5
 shortuuid==1.0.1
 tabulate==0.8.7
+numpy==1.20.3
 cbpi4ui
-click
+click==7.1.2
+importlib_metadata==4.8.2
 asyncio-mqtt
+psutil==5.8.0
+zipp>=0.5


### PR DESCRIPTION
With this change, cbpi is installed in a virtual environment in the docker container. This avoids having to install cbpi as root. And this leads to easier handling of plugins in the docker container, as the user does not have to be switched while installing plugins.

I will update the documentation when the PR is merged.