### PR TITLE
Reduce build time for docker image on GitHub actions by using a cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,50 @@
+# Docker
+docker-compose.yml
+.docker
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+**/__pycache__
+**/*.py[cod]
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Virtual environment
+.env/
+.venv/
+venv/
+venv3/
+
+*.cover
+*.log
+.git
+.mypy_cache
+.pytest_cache
+.hypothesis
+.idea
+
+**/*.swp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,8 @@ jobs:
           target: deploy
           push: ${{ steps.prep.outputs.publish_image }}
           tags: ${{ steps.prep.outputs.tags }}
+          cache-from: type=registry,ref=${{ steps.prep.outputs.build_cache_image_name }}
+          cache-to: type=inline
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,7 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
+          target: deploy
           push: ${{ steps.prep.outputs.publish_image }}
           tags: ${{ steps.prep.outputs.tags }}
           labels: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,11 +54,17 @@ jobs:
           PUBLISH_IMAGE=false
           TAGS="${{ env.image-name }}:dev"
 
+          # Define the image that will be used as a cached image
+          # to speed up the build process
+          BUILD_CACHE_IMAGE_NAME=${TAGS}
+
           if [[ $GITHUB_REF_NAME == master ]] || [[ $GITHUB_REF_NAME == main ]]; then
             # when building master/main use :latest tag and the version number
             # from the cbpi/__init__.py file
             VERSION=$(grep -o -E "(([0-9]{1,2}[.]?){3}[0-9]+)" cbpi/__init__.py)
-            TAGS="${{ env.image-name }}:latest,${{ env.image-name }}:v${VERSION}"
+            LATEST_IMAGE=${{ env.image-name }}:latest
+            BUILD_CACHE_IMAGE_NAME=${LATEST_IMAGE}
+            TAGS="${LATEST_IMAGE},${{ env.image-name }}:v${VERSION}"
             PUBLISH_IMAGE=true
           elif [[ $GITHUB_REF_NAME == development ]]; then
             PUBLISH_IMAGE=true
@@ -67,6 +73,7 @@ jobs:
           # Set output parameters.
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=publish_image::${PUBLISH_IMAGE}
+          echo ::set-output name=build_cache_image_name::${BUILD_CACHE_IMAGE_NAME}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel
 COPY --chown=craftbeerpi ./requirements.txt /cbpi-src/
 RUN pip3 install --no-cache-dir -r /cbpi-src/requirements.txt
 
+FROM base as deploy
 # Install craftbeerpi from source
 COPY --chown=craftbeerpi . /cbpi-src
 RUN pip3 install --no-cache-dir /cbpi-src

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN apk --no-cache add curl && mkdir /downloads
 # Download installation files
 RUN curl https://github.com/avollkopf/craftbeerpi4-ui/archive/main.zip -L -o ./downloads/cbpi-ui.zip
 
-FROM python:3.9
+FROM python:3.7 as base
 
 # Install dependencies
 RUN     apt-get update \


### PR DESCRIPTION
In the PR #13 I changed the python version in the docker image to 3.9. This seems to make the build increadibly slow. I think this is because there are no prebuilt packages for the dependencies of cbpi when installing them on an arm image.

So in this PR I did the following:
- Use Python 3.7 base image (--> this reduces the build time to <10 min)
- Use previously built images as cache (--> when the dependencies don't change this reduces the build time to <5 min)
  This needs one successful build on the target branch to take effect. 

I tested this in my fork, see:
![Build performance increase](https://user-images.githubusercontent.com/2471424/144709284-3a53f10b-d995-458d-8d6b-fbb02fade7fa.png)

