### PR TITLE
Install RPi.GPIO in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,11 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel
 COPY --chown=craftbeerpi ./requirements.txt /cbpi-src/
 RUN pip3 install --no-cache-dir -r /cbpi-src/requirements.txt
 
+# Install RPi.GPIO separately because it's excluded in setup.py for non-raspberrys.
+# This can enable GPIO support for the image when used on a raspberry pi and the
+# /dev/gpiomem device.
+RUN pip3 install --no-cache-dir RPi.GPIO==0.7.1a4
+
 FROM base as deploy
 # Install craftbeerpi from source
 COPY --chown=craftbeerpi . /cbpi-src


### PR DESCRIPTION
When installing CraftBeerPi the `RPi.GPIO` package is only installed when the host is a raspberry pi. At least that's what I understood from the setup.py file. I'm not sure why this exception is beeing made.

To still be able to use the package within the docker image this PR adds it separately in the image. This may help to be able to use GPIO with the image when using it on a raspberry.

Starting the image with the `RPi.GPIO` package installed and the `/dev/gpiomem` device mapped does not log the error at startup that the GPIO Mock is used instead of `RPi.GPIO`. Unfortunately I don't know if it really works because I don't have a device that I could connect via GPIO and wouldn't know what to test. 