### PR TITLE
Update github build workflow and docker image to python 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup python environment
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.9'
 
       - name: Clean
         run: python setup.py clean --all

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN apk --no-cache add curl && mkdir /downloads
 # Download installation files
 RUN curl https://github.com/avollkopf/craftbeerpi4-ui/archive/main.zip -L -o ./downloads/cbpi-ui.zip
 
-FROM python:3.7 as base
+FROM python:3.9 as base
 
 # Install dependencies
 RUN     apt-get update \

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,10 +10,10 @@ cryptography==3.3.2
 requests==2.25.1 
 voluptuous==0.12.1 
 pyfiglet==0.8.post1 
-pandas==1.1.5
+pandas==1.4.0
 shortuuid==1.0.1
 tabulate==0.8.7
-numpy==1.20.3
+numpy==1.22.0
 cbpi4ui
 click==7.1.2
 importlib_metadata==4.8.2


### PR DESCRIPTION
As mentioned in #39 the docker image was previously built with python v3.7. The build is now much faster because the newer packages for pandas and numpy seem to be available as prebuilt packages for arm64.

I updated the `requirements.txt` this means that the development should happen with python 3.9 if I understood the conversation in the previously mentioned issue correctly. I left the `setup.py` untouched, as I am not sure if cbpi should also support python 3.7 or if this was just to support the docker build infrastructure.

I built the image on my dev machine and it runs fine. Can't test the `arm64` image at the moment - but the built that was running in my repo for testing the changes was successful. 