### PR TITLE
imports the whirlpool hop addition kbh with timer

### DIFF
--- a/cbpi/controller/upload_controller.py
+++ b/cbpi/controller/upload_controller.py
@@ -202,11 +202,6 @@ class UploadController:
                 for whirl in whirlpool:
                     hops.remove(whirl)
 
-                print(whirlpool)
-                print(hops)
-                
-
-
                 # get the misc addition times
                 c.execute('SELECT Zugabedauer FROM WeitereZutatenGaben WHERE Zeitpunkt = 1 AND SudID = ?', (Recipe_ID,))
                 miscs = c.fetchall()
@@ -318,8 +313,11 @@ class UploadController:
 
                 await self.create_step(step_string)
 
-                await self.create_Whirlpool_Cooldown(str(abs(whirlpool[0][0]))) # from kbh this value comes as negative but must be positive
- 
+                if not whirlpool:
+                    await self.create_Whirlpool_Cooldown()
+                else :
+                    await self.create_Whirlpool_Cooldown(str(abs(whirlpool[0][0]))) # from kbh this value comes as negative but must be positive
+
                 self.cbpi.notify('KBH Recipe created', name, NotificationType.INFO)
 
             except:

--- a/cbpi/controller/upload_controller.py
+++ b/cbpi/controller/upload_controller.py
@@ -193,8 +193,19 @@ class UploadController:
                     pass
 
                 # get the hop addition times
-                c.execute('SELECT Zeit FROM Hopfengaben WHERE Vorderwuerze <> 1 AND Vorderwuerze <> 5 AND SudID = ?', (Recipe_ID,))
+                c.execute('SELECT Zeit FROM Hopfengaben WHERE Vorderwuerze <> 1 AND SudID = ?', (Recipe_ID,))
                 hops = c.fetchall()
+                whirlpool = []
+                for hop in hops:
+                    if hop[0] < 0:
+                        whirlpool.append(hop)
+                for whirl in whirlpool:
+                    hops.remove(whirl)
+
+                print(whirlpool)
+                print(hops)
+                
+
 
                 # get the misc addition times
                 c.execute('SELECT Zugabedauer FROM WeitereZutatenGaben WHERE Zeitpunkt = 1 AND SudID = ?', (Recipe_ID,))
@@ -307,7 +318,7 @@ class UploadController:
 
                 await self.create_step(step_string)
 
-                await self.create_Whirlpool_Cooldown()
+                await self.create_Whirlpool_Cooldown(str(abs(whirlpool[0][0]))) # from kbh this value comes as negative but must be positive
  
                 self.cbpi.notify('KBH Recipe created', name, NotificationType.INFO)
 
@@ -946,13 +957,13 @@ class UploadController:
                 alert="Yes"
         return alert
 
-    async def create_Whirlpool_Cooldown(self):
+    async def create_Whirlpool_Cooldown(self, time : str = "15"):
         # Add Waitstep as Whirlpool
         if self.cooldown != "WaiStep" and self.cooldown !="":
             step_string = { "name": "Whirlpool",
                             "props": {
                                 "Kettle": self.boilid,
-                                "Timer": "15"
+                                "Timer": time
                                 },
                             "status_text": "",
                             "status": "I",
@@ -965,7 +976,7 @@ class UploadController:
         step_name = "CoolDown"
         cooldown_sensor = ""
         step_temp = ""
-        step_timer = "15"
+        step_timer = time
         if step_type == "CooldownStep":
             cooldown_sensor = self.cbpi.config.get("steps_cooldown_sensor", None)
             if cooldown_sensor is None or cooldown_sensor == '':


### PR DESCRIPTION
previously the whirlpool step has been ignored when importing from a kbh database.

It
1. allows whirlpool data to be selected from the database
2. sorts hop additions and whirlpool additions into the variables hops and whirlpool (thus removing whirlpool additions from the hops variable and restoring its state as if whirlpool data was not selected from the database as before)
3. takes the first whirlpool addition time, gets rid of the sign and gives it to the creation of the whirlpool step. (first one is enough because the whirlpool additions all happen at the same time)

on creation the whirlpool would only be on a hardcoded 15 minute timer.
I added the optional timer as argument to `create_Whirlpool_Cooldown()`.
And made use of it for negative hops timer imported from KBH.
For KBH databases this is valid because if the hops timer value is negative it can only be the whirlpool timer
and the value is the time that is set for the brewing device for getting from boil to below 80°C.
I did only test the data and not the functionality,
but it sucessfully replaces the hardcoded "15" timer with the value
from the first whirlpool hop addition while getting rid of the sign.