### PR TITLE
Copy dashboard files from config folder to config/dashboard when upgr…

### DIFF
--- a/cbpi/configFolder.py
+++ b/cbpi/configFolder.py
@@ -8,7 +8,7 @@ import shutil
 import zipfile
 from pathlib import Path
 import glob
-
+import json
 
 class ConfigFolder:
     def __init__(self, configFolderPath, logsFolderPath):
@@ -121,9 +121,23 @@ class ConfigFolder:
         # if cbpi_dashboard_1.json doesnt exist at the new location (configFolderPath/dashboard)
         # we move every cbpi_dashboard_n.json file from the old location (configFolderPath) there.
         # this could be a config zip file restore from version 4.0.7.a4 or prior.
-        if not (os.path.isfile(os.path.join(self.configFolderPath, 'dashboard', 'cbpi_dashboard_1.json'))):
+        dashboard_1_path = os.path.join(self.configFolderPath, 'dashboard', 'cbpi_dashboard_1.json')
+        if (not (os.path.isfile(dashboard_1_path))) or self.check_for_empty_dashboard_1(dashboard_1_path):
             for file in glob.glob(os.path.join(self.configFolderPath, 'cbpi_dashboard_*.json')):
-                shutil.move(file, os.path.join(self.configFolderPath, 'dashboard', os.path.basename(file)))
+                dashboardFile = os.path.basename(file)
+                print(f"Copy dashboard json file {dashboardFile} from config to config/dashboard folder")
+                shutil.move(file, os.path.join(self.configFolderPath, 'dashboard', dashboardFile))
+
+    def check_for_empty_dashboard_1(self, dashboard_1_path):
+        try:
+            with open(dashboard_1_path, 'r') as f:
+                data = json.load(f)
+            if (len(data['elements']) == 0):  # there may exist some pathes but pathes without elements in dashboard is not very likely
+                return True
+            else:
+                return False
+        except: # file missing or bad json format
+            return True
     
     def inform_missing_content(self, whatsmissing : str):
         if whatsmissing == "":


### PR DESCRIPTION
In addidition check now on empty dashboard file in config/dashboard folder when upgrading to version 4.0.7. to enable moving dashboard files. In earlier versions cbpi setup generated an empty dashboard file in config/dashboard folder, which prevents moving dashboard files to new location.