### PR TITLE
Hysteresis extension: switch heater only on/off once

### DIFF
--- a/cbpi/__init__.py
+++ b/cbpi/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "4.1.2"
+__version__ = "4.1.3"
 __codename__ = "Groundhog Day"
 


### PR DESCRIPTION
change solves an issue with the mqtt device as actor was triggered every second w/o need. This caused overflow in the mqttdevice in case of mqtt actors.

-> Actor status checked prior to switching